### PR TITLE
Use go's context.Context

### DIFF
--- a/cmd_invoker.go
+++ b/cmd_invoker.go
@@ -36,6 +36,11 @@ func NewCmdInvoker(cmd *exec.Cmd) (Invoker, error) {
 		return nil, err
 	}
 
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
 	p := &cmdInvoker{
 		cmd:    cmd,
 		stdin:  stdin,
@@ -50,12 +55,7 @@ func (cf *cmdInvoker) Invoke(ctx context.Context, input *Input) (*Result, error)
 		return nil, ErrMissingTimeout
 	}
 
-	err := cf.cmd.Start()
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = input.WriteTo(cf.stdin)
+	_, err := input.WriteTo(cf.stdin)
 	if err != nil {
 		cf.cmd.Process.Kill()
 		return nil, err

--- a/cmd_invoker_test.go
+++ b/cmd_invoker_test.go
@@ -11,20 +11,14 @@ import (
 	protoio "github.com/tessellator/protoio"
 )
 
-func TestCmdInvoker_Invoke_commmandDoesNotExist(t *testing.T) {
+func TestNewCmdInvoker(t *testing.T) {
 	t.Run("with an executable that does not exist", func(t *testing.T) {
 		cmd := exec.Command("does_not_exist")
-		invoker, err := NewCmdInvoker(cmd)
 
-		if err != nil {
-			t.Fatalf("NewCmdInvoker() returned error: %+v", err)
-		}
-
-		input := Input{}
-		_, err = invoker.Invoke(context.Background(), &input)
+		_, err := NewCmdInvoker(cmd)
 
 		if err == nil {
-			t.Errorf("Invoke() did not return error")
+			t.Errorf("NewCmdInvoker() did not return error")
 		}
 	})
 }

--- a/invoker_test.go
+++ b/invoker_test.go
@@ -3,6 +3,7 @@ package fnrun
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -14,15 +15,14 @@ func TestExecutionContext_WriteTo(t *testing.T) {
 	vars := make(map[string]string)
 	vars["hello"] = "world"
 
-	ctx := ExecutionContext{
-		MaxRunnableTime: 30 * time.Second,
-		Env:             vars,
-	}
+	ctx := WithEnv(context.Background(), vars)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
 
-	_, err := ctx.WriteTo(w)
+	_, err := WriteTo(ctx, w)
 	if err != nil {
 		t.Fatalf("WriteTo() got err: %+v", err)
 	}


### PR DESCRIPTION
Lemme know if you find this valuable!  Works just fine without these changes, too, so really just up to you if you want them.

This makes the existing code a bit more idiomatic by using the builtin `context.Context` type in place of `ExecutionContext`.  Timeouts are handled through `context.WithTimeout`, `context.DeadlineExceeded` is used in place of `ErrExecutionTimeout`, and `context.Value` is used to store the environment variable mapping.

This also allows for cancellation functions to be passed down as a future enhancement.

It also adds a guarantee around consistency - the command is started on `Invoke`, and the timeout captures the entire run of the command.  (In practice, the time spent executing before the timeout took effect was pretty negligible, but nice to have the guarantee.)